### PR TITLE
Add build script that doesn't invoke cabal directly

### DIFF
--- a/withHakyll_build.sh
+++ b/withHakyll_build.sh
@@ -1,0 +1,7 @@
+mkdir dist
+set -e
+ghc -threaded -o dist/pkg Setup.hs
+dist/pkg configure
+dist/pkg build
+dist/build/ruHaskell/ruHaskell build
+dist/build/ruHaskell/ruHaskell check


### PR DESCRIPTION
On some systems (like NixOS or nix-env powered linuxi),
invoking cabal directly is considered to be an anti-pattern.
Starting ``nix`` branch of ruhaskell, I aim to maintain
project's compatibility with such systems.
First step is a "simple" build script that expects dependencies
to be in library search path.

Eventually, we'll have a nix expression for the project, generated
with ``cabal2nix`` and ``shell.nix`` for sandbox-development.

If there are Nix users, who have time, please go ahead and
contribute to better integration of ruhaskell with Nix ecosystem!